### PR TITLE
Use ECR jenkins inbound image when needed using IAM execution role for jenkins

### DIFF
--- a/modules/jenkins_platform/docker/files/jenkins.yaml.tpl
+++ b/modules/jenkins_platform/docker/files/jenkins.yaml.tpl
@@ -33,6 +33,7 @@ jenkins:
                   - cpu: "512"
                     image: "jenkins/inbound-agent"
                     label: "build-example-spot"
+                    execution_role_arn: ${execution_role_arn}
                     launchType: "FARGATE"
                     memory: 0
                     memoryReservation: 1024
@@ -56,6 +57,7 @@ jenkins:
                   - cpu: "512"
                     image: "jenkins/inbound-agent"
                     label: "build-example"
+                    execution_role_arn: ${execution_role_arn}
                     launchType: "FARGATE"
                     memory: 0
                     memoryReservation: 1024

--- a/modules/jenkins_platform/jenkins_image.tf
+++ b/modules/jenkins_platform/jenkins_image.tf
@@ -27,6 +27,7 @@ data "template_file" jenkins_configuration_def {
     jenkins_controller_port       = var.jenkins_controller_port
     jnlp_port                 = var.jenkins_jnlp_port
     agent_security_groups     = aws_security_group.jenkins_controller_security_group.id
+    execution_role_arn        = aws_iam_role.ecs_execution_role.arn
     subnets                   = join(",", var.jenkins_controller_subnet_ids)
   }
 }


### PR DESCRIPTION
*Description of changes:*

Updated the jenkins.yaml.tpl and jenkins template to have execution role. This will enable to pull images from ECR instead of docker hub when needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
