### PR TITLE
resolve plugin dependency issue

### DIFF
--- a/modules/jenkins_platform/docker/files/plugins.txt
+++ b/modules/jenkins_platform/docker/files/plugins.txt
@@ -24,7 +24,7 @@ git:4.14.2
 github-api:1.303-400.v35c2d8258028
 github:1.36.0
 handlebars:3.0.8
-jackson2-api:2.13.4.20221013-295.v8e29ea_354141
+jackson2-api:2.14.2-319.v37853346a_229
 jdk-tool:63.v62d2fd4b_4793
 job-dsl:1.77
 jquery-detached:1.2.1
@@ -51,7 +51,7 @@ pipeline-stage-view:2.28
 plain-credentials:139.ved2b_9cf7587b
 resource-disposer:0.19
 scm-api:621.vda_a_b_055e58f7
-script-security:1218.v39ca_7f7ed0a_c
+script-security:1228.vd93135a_2fb_25
 snakeyaml-api:1.33-90.v80dcb_3814d35 
 ssh-credentials:305.v8f4381501156
 structs:324.va_f5d6774f3a_d


### PR DESCRIPTION
Resolves plugin dependency issue below.

Error during docker image build of jenkins image:

Plugin aws-credentials:191.vcb_f183ce58b_9 (via aws-java-sdk-ec2:1.12.406-370.v8f993c987059->aws-java-sdk-minimal:1.12.406-370.v8f993c987059) depends on
│ jackson2-api:2.14.2-319.v37853346a_229, but there is an older version defined on the top level - jackson2-api:2.13.4.20221013-295.v8e29ea_354141,
│ Plugin aws-java-sdk:1.12.287-357.vf82d85a_6eefd (via aws-java-sdk-minimal:1.12.406-370.v8f993c987059) depends on jackson2-api:2.14.2-319.v37853346a_229, but
│ there is an older version defined on the top level - jackson2-api:2.13.4.20221013-295.v8e29ea_354141,
│ Plugin pipeline-github-lib:38.v445716ea_edda_ (via pipeline-groovy-lib:629.vb_5627b_ee2104) depends on script-security:1228.vd93135a_2fb_25, but there is an
│ older version defined on the top level - script-security:1218.v39ca_7f7ed0a_c,
│ Plugin pipeline-model-definition:2.2118.v31fd5b_9944b_5 (via pipeline-groovy-lib:629.vb_5627b_ee2104) depends on script-security:1228.vd93135a_2fb_25, but
│ there is an older version defined on the top level - script-security:1218.v39ca_7f7ed0a_c,
│ Plugin workflow-aggregator:590.v6a_d052e5a_a_b_5 (via pipeline-groovy-lib:629.vb_5627b_ee2104) depends on script-security:1228.vd93135a_2fb_25, but there is
│ an older version defined on the top level - script-security:1218.v39ca_7f7ed0a_c,
│ Plugin workflow-cps-global-lib:609.vd95673f149b_b (via pipeline-groovy-lib:629.vb_5627b_ee2104) depends on script-security:1228.vd93135a_2fb_25, but there is
│ an older version defined on the top level - script-security:1218.v39ca_7f7ed0a_c
│ The command '/bin/sh -c jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt' returned a non-zero code: 1